### PR TITLE
fix np.int error and adapt to numpy 1.20+

### DIFF
--- a/utils/utils_metrics.py
+++ b/utils/utils_metrics.py
@@ -121,7 +121,7 @@ def compute_mIoU(gt_dir, pred_dir, png_name_list, num_classes, name_classes=None
     #   在所有验证集图像上求所有类别平均的mIoU值，计算时忽略NaN值
     #-----------------------------------------------------------------#
     print('===> mIoU: ' + str(round(np.nanmean(IoUs) * 100, 2)) + '; mPA: ' + str(round(np.nanmean(PA_Recall) * 100, 2)) + '; Accuracy: ' + str(round(per_Accuracy(hist) * 100, 2)))  
-    return np.array(hist, np.int), IoUs, PA_Recall, Precision
+    return np.array(hist, dtype=int), IoUs, PA_Recall, Precision
 
 def adjust_axes(r, t, fig, axes):
     bb                  = t.get_window_extent(renderer=r)

--- a/voc_annotation.py
+++ b/voc_annotation.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     print("Check datasets format, this may take a while.")
     print("检查数据集格式是否符合要求，这可能需要一段时间。")
-    classes_nums        = np.zeros([256], np.int)
+    classes_nums        = np.zeros([256], dtype=int)
     for i in tqdm(list):
         name            = total_seg[i]
         png_file_name   = os.path.join(segfilepath, name)


### PR DESCRIPTION
numpy 1.20+有如下报错：
AttributeError: module 'numpy' has no attribute 'int'.

`np.int`已经被弃用，替换为`int`